### PR TITLE
Use cross-platform path separator in #include directives

### DIFF
--- a/ILI9341_due.cpp
+++ b/ILI9341_due.cpp
@@ -45,7 +45,7 @@ MIT license, all text above must be included in any redistribution.
 #include <SPI.h>
 #endif
 
-//#include "..\Streaming\Streaming.h"
+//#include "../Streaming/Streaming.h"
 
 #pragma GCC diagnostic push 
 #pragma GCC diagnostic ignored "-Wattributes"

--- a/examples/arcs/arcs.ino
+++ b/examples/arcs/arcs.ino
@@ -2,7 +2,7 @@
 #include <SPI.h>
 #include <ILI9341_due_config.h>
 #include <ILI9341_due.h>
-#include "fonts\Arial_bold_14.h"
+#include "fonts/Arial_bold_14.h"
 #include "roboto16.h"
 #include "roboto32.h"
 #include "roboto70.h"

--- a/examples/gTextBigFont/gTextBigFont.ino
+++ b/examples/gTextBigFont/gTextBigFont.ino
@@ -2,7 +2,7 @@
 #include <ILI9341_due_config.h>
 #include <ILI9341_due.h>
 
-#include "fonts\jokerman_255.h"
+#include "fonts/jokerman_255.h"
 
 #define TFT_CS 10
 #define TFT_DC 9

--- a/examples/gTextHelloWorld/gTextHelloWorld.ino
+++ b/examples/gTextHelloWorld/gTextHelloWorld.ino
@@ -2,7 +2,7 @@
 #include <ILI9341_due_config.h>
 #include <ILI9341_due.h>
 
-#include "fonts\Arial_bold_14.h"
+#include "fonts/Arial_bold_14.h"
 
 #define TFT_CS 10
 #define TFT_DC 9

--- a/examples/graphicstestWithStats/graphicstestWithStats.ino
+++ b/examples/graphicstestWithStats/graphicstestWithStats.ino
@@ -17,8 +17,8 @@ MIT license, all text above must be included in any redistribution
 #include <SPI.h>
 #include <ILI9341_due_config.h>
 #include <ILI9341_due.h>
-#include "fonts\SystemFont5x7.h"
-#include "fonts\Arial_bold_14.h"
+#include "fonts/SystemFont5x7.h"
+#include "fonts/Arial_bold_14.h"
 
 #define TFT_RST 8
 #define TFT_DC 9

--- a/examples/uTouchButtonTest/uTouchButtonTest.ino
+++ b/examples/uTouchButtonTest/uTouchButtonTest.ino
@@ -1,7 +1,7 @@
 #include <SPI.h>
 #include <ILI9341_due_config.h>
 #include <ILI9341_due.h>
-#include "fonts\Arial_bold_14.h"
+#include "fonts/Arial_bold_14.h"
 
 #include <URTouch.h>
 

--- a/examples/uTouchQuickPaint/uTouchQuickPaint.ino
+++ b/examples/uTouchQuickPaint/uTouchQuickPaint.ino
@@ -1,7 +1,7 @@
 #include <SPI.h>
 #include <ILI9341_due_config.h>
 #include <ILI9341_due.h>
-#include "fonts\Arial_bold_14.h"
+#include "fonts/Arial_bold_14.h"
 
 #include <URTouch.h>
 


### PR DESCRIPTION
Use of the \ path separator causes compilation to fail on any OS other than Windows.